### PR TITLE
Resolve permission errors on lambda execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 hello
 hello.zip
+/build

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,16 @@ GOPATH ?= $(HOME)/projects/go-workspace
 all: hello.zip
 
 hello.zip: hello
-	zip $@ lambda-hello.js $<
+	mkdir -p build
+	cp $< lambda-hello.js build
+	chmod -R a+r build/*
+	chmod -R a-w build/*
+	chmod a+x build/hello
+	zip -Xjr $@ build
 
 hello: hello.go
-	docker-compose run build
+	docker-compose run build go build hello.go
 
 .PHONY: clean
 clean:
-	rm -f hello hello.zip
+	rm -rf hello hello.zip build

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,10 @@
+# Automatic make variables used in this file
+# (see https://www.gnu.org/software/make/manual/html_node/Automatic-Variables.html)
+#
+# - $@ - the target / output of the rule. Think "dartboard".
+# - $^ - the dependencies / inputs of the rule. Imagine an arrow pointing up to
+#     the dependency list.
+
 GOPATH ?= $(HOME)/projects/go-workspace
 
 .PHONY: all
@@ -5,7 +12,7 @@ all: hello.zip
 
 hello.zip: hello
 	mkdir -p build
-	cp $< lambda-hello.js build
+	cp $^ lambda-hello.js build/
 	chmod -R a+r build/*
 	chmod -R a-w build/*
 	chmod a+x build/hello

--- a/README.md
+++ b/README.md
@@ -10,4 +10,14 @@ You need docker-compose, and docker-machine + environment if on a mac
 # Usage
 
 1. Run `make`. This will generate `hello.zip` which you can upload to s3 and
-     use as the source of a lambda function.
+    use as the source of a lambda function.
+1. Create a lambda function in aws
+    1. Use the `node.js` runtime
+    1. "Code entry type" should be `upload a zip file`, with `hello.zip`
+    1. "Handler" should be `hello-lambda.handler`, because the file is called
+        `hello-lambda.js`
+    1. Create a new role from the "Basic Execution Role"
+1. Test it out. Click the "test" button.
+    1. Once clicked, scroll down to see any errors that occurred.
+    1. Click the "monitoring" tab, and then "View logs in Cloudwatch" for more
+        specific error message.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ build:
   volumes:
     - '.:/go/src/github.com/des4maisons/lambda-hello'
   working_dir: '/go/src/github.com/des4maisons/lambda-hello'
-  command: 'go build hello.go'
   environment:
     - GOOS=linux
     - GOARCH=amd64

--- a/echo_request_payload.js
+++ b/echo_request_payload.js
@@ -1,0 +1,5 @@
+exports.handler = function(event, context) {
+    console.log(JSON.stringify(event));
+    context.done(null);
+};
+


### PR DESCRIPTION
Otherwise, I get the following error in the cloudwatch logs:

```
module initialization error: Error
at Object.fs.openSync (fs.js:439:18)
at Object.fs.readFileSync (fs.js:290:15)
at Object.Module._extensions..js (module.js:473:44)
at Module.load (module.js:356:32)
at Function.Module._load (module.js:312:12)
at Module.require (module.js:364:17)
at require (module.js:380:17)
```

And if I scroll down after clicking the "test" button in on the configuration
page, I see:

```
{
  "errorMessage": "EACCES, permission denied '/var/task/lambda-hello.js'",
  "errorType": "Error",
  "stackTrace": [
    "Object.fs.openSync (fs.js:439:18)",
    "Object.fs.readFileSync (fs.js:290:15)",
    "Object.Module._extensions..js (module.js:473:44)",
    "Module.load (module.js:356:32)",
    "Function.Module._load (module.js:312:12)",
    "Module.require (module.js:364:17)",
    "require (module.js:380:17)"
  ]
}
```